### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build_check_deploy.yaml
+++ b/.github/workflows/build_check_deploy.yaml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Publish to Registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: docker.pkg.github.com/${{ github.repository }}/sqligther:latest
           username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore